### PR TITLE
Special chars escaping improvement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,11 +113,15 @@ function generateCsv(json, callback) {
     else if(_.isObject(json)){
         var fileRows = [];
         var horizontalRows = [[],[]];
+        var textDelimiterRegex = new RegExp(options.textDelimiter, 'g');
         for(var prop in json){
             var parseResult = checkType(json[prop], prop);
             parseResult.forEach(function (result) {
 
                 var value = result.value || options.undefinedString;
+                // Escape the textDelimiters contained in the field
+                value = value.replace(textDelimiterRegex, options.textDelimiter+options.textDelimiter);
+                // Escape the whole field if it contains a rowDelimiter
                 if (value.indexOf(options.rowDelimiter) >= 0) {
                   value = options.textDelimiter + value + options.textDelimiter;
                 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,6 +120,12 @@ function generateCsv(json, callback) {
 
                 var value = result.value || options.undefinedString;
                 // Escape the textDelimiters contained in the field
+                /*(https://tools.ietf.org/html/rfc4180)
+                   7.  If double-quotes are used to enclose fields, then a double-quote
+                   appearing inside a field must be escaped by preceding it with
+                   another double quote.  
+                   For example: "aaa","b""bb","ccc"
+                */
                 value = value.replace(textDelimiterRegex, options.textDelimiter+options.textDelimiter);
                 // Escape the whole field if it contains a rowDelimiter
                 if (value.indexOf(options.rowDelimiter) >= 0 || value.indexOf('\n') >= 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,7 @@ function generateCsv(json, callback) {
                 // Escape the textDelimiters contained in the field
                 value = value.replace(textDelimiterRegex, options.textDelimiter+options.textDelimiter);
                 // Escape the whole field if it contains a rowDelimiter
-                if (value.indexOf(options.rowDelimiter) >= 0) {
+                if (value.indexOf(options.rowDelimiter) >= 0 || value.indexOf('\n') >= 0) {
                   value = options.textDelimiter + value + options.textDelimiter;
                 }
                 //Type header;value

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonexport",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Makes easy to convert JSON to CSV",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
Hi there,

I added the escaping for the newline char, as you suggested. Reading the specs [here](https://tools.ietf.org/html/rfc4180), it turned out that i also forgot to escape the textDelimiter if it's contained in the field, so i fixed that too.

However, as the spec says  "Fields containing line breaks (CRLF), double quotes, and commas should be enclosed in double-quotes.", i don't know if i should hardcode these chars or run the check on the dynamic options fields (rowDelimiter and endOfLine). Or maybe both ? What do u think ?

It may be worth to note that the escaping occurs only if the json is an Object, i didn't changed the Array part of the lib, because i can't spend more time on it today.

Let me know if you need me to dig it deeper :) 