### PR TITLE
The default date format includes a comma, which makes CSV output look incorrect.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -368,5 +368,5 @@ function handleNumber(number){
  */
 function handleDate(date){
     //Finished, returning the number now
-    return date.toLocaleString();
+    return date.toLocaleDateString();
 }


### PR DESCRIPTION
The default date handler includes a comma, which can make the CSV output look off by one or more depending on the number of dates in your object.

```javascript
> var now = new Date;
> now.toLocaleString();
=> "12/3/2016, 7:06:48 PM"

// compare to
> var now = new Date;
=> "12/3/2016"
```

The downside is the default handler will not include time, but the user can override by configuring a custom method in `options`.
