### PR TITLE
update checkType function to handle types not covered by the conditionals.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -234,6 +234,12 @@ function checkType(element, item){
         var resultObject = handleObject(element, item);
         result = headers(resultObject, item);
     }
+    else{
+        result = [{
+            item: item,
+            value: 'None',
+        }];
+    }
     return result;
 }
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -237,7 +237,7 @@ function checkType(element, item){
     else{
         result = [{
             item: item,
-            value: 'None',
+            value: '',
         }];
     }
     return result;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonexport",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Makes easy to convert JSON to CSV",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
I got an {"error":"Cannot read property 'item' of undefined"} when handing over json with properties like { my_key: null}