### PR TITLE
Adds ability to force text delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ In order to get the most of out of this module, you can customize many parameter
     - Use `\t` for **xls format**.
     - Use `;` for (**windows excel .csv format**).
 - `textDelimiter` - `String` The character used to escape the text content if needed (default to `"`)
+- `forceTextDelim` - `Boolean` Set this option to true to wrap every data item and header in the textDelimiter. Defaults to `"`
 - `endOfLine` - `String` Replace the OS default EOL.
 - `mainPathItem` - `String` Every header will have the `mainPathItem` as the base.
 - `arrayPathString` - `String` This is used to output primitive arrays in a single column, defaults to `;`

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ In order to get the most of out of this module, you can customize many parameter
     - Use `\t` for **xls format**.
     - Use `;` for (**windows excel .csv format**).
 - `textDelimiter` - `String` The character used to escape the text content if needed (default to `"`)
-- `forceTextDelim` - `Boolean` Set this option to true to wrap every data item and header in the textDelimiter. Defaults to `false`
+- `forceTextDelimiter` - `Boolean` Set this option to true to wrap every data item and header in the textDelimiter. Defaults to `false`
 - `endOfLine` - `String` Replace the OS default EOL.
 - `mainPathItem` - `String` Every header will have the `mainPathItem` as the base.
 - `arrayPathString` - `String` This is used to output primitive arrays in a single column, defaults to `;`

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ In order to get the most of out of this module, you can customize many parameter
     - Use `\t` for **xls format**.
     - Use `;` for (**windows excel .csv format**).
 - `textDelimiter` - `String` The character used to escape the text content if needed (default to `"`)
-- `forceTextDelim` - `Boolean` Set this option to true to wrap every data item and header in the textDelimiter. Defaults to `"`
+- `forceTextDelim` - `Boolean` Set this option to true to wrap every data item and header in the textDelimiter. Defaults to `false`
 - `endOfLine` - `String` Replace the OS default EOL.
 - `mainPathItem` - `String` Every header will have the `mainPathItem` as the base.
 - `arrayPathString` - `String` This is used to output primitive arrays in a single column, defaults to `;`

--- a/README.md
+++ b/README.md
@@ -338,4 +338,5 @@ var options={
 - [Kauê Gimenes](https://github.com/kauegimenes)
 - [Pierre Guillaume](https://github.com/papswell)
 - [Acker Apple](https://github.com/AckerApple) [![hire me](https://ackerapple.github.io/resume/assets/images/hire-me-badge.svg)](https://ackerapple.github.io/resume/)
+- [Victor Hahn](https://github.com/rv-vhahn)
 - [And many more...](https://github.com/kauegimenes/jsonexport/graphs/contributors)

--- a/dist/core/escape-delimiters.js
+++ b/dist/core/escape-delimiters.js
@@ -9,7 +9,7 @@
    For example: "aaa","b""bb","ccc"
 */
 
-module.exports = function escapedDelimiters(textDelimiter, rowDelimiter) {
+module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTextDelimiter) {
   var endOfLine = '\n';
 
   if (typeof textDelimiter !== 'string') {
@@ -30,14 +30,17 @@ module.exports = function escapedDelimiters(textDelimiter, rowDelimiter) {
   };
 
   return function (value) {
+    if (forceTextDelimiter) value = "" + value;
+
     if (!value.replace) return value;
     // Escape the textDelimiters contained in the field
-    var newValue = value.replace(textDelimiterRegex, escapedDelimiter);
+    value = value.replace(textDelimiterRegex, escapedDelimiter);
+
     // Escape the whole field if it contains a rowDelimiter or a linebreak or double quote
-    if (enclosingCondition(value)) {
-      newValue = textDelimiter + newValue + textDelimiter;
+    if (forceTextDelimiter || enclosingCondition(value)) {
+      value = textDelimiter + value + textDelimiter;
     }
 
-    return newValue;
+    return value;
   };
 };

--- a/dist/parser/csv.js
+++ b/dist/parser/csv.js
@@ -21,7 +21,7 @@ var Parser = function () {
     this._options = this._parseOptions(options) || {};
     this._handler = new Handler(this._options);
     this._headers = this._options.headers || [];
-    this._escape = require('../core/escape-delimiters')(this._options.textDelimiter, this._options.rowDelimiter);
+    this._escape = require('../core/escape-delimiters')(this._options.textDelimiter, this._options.rowDelimiter, this._options.forceTextDelimiter);
   }
 
   /**
@@ -260,6 +260,7 @@ var Parser = function () {
         includeHeaders: true, //     Boolean
         fillGaps: false, //          Boolean
         verticalOutput: true, //     Boolean
+        forceTextDelimiter: false, //Boolean
         //Handlers
         handleString: undefined, //  Function
         handleNumber: undefined, //  Function
@@ -274,9 +275,17 @@ var Parser = function () {
       var _this = this;
 
       var headers = this._headers;
+
       if (this._options.rename && this._options.rename.length > 0) headers = headers.map(function (header) {
         return _this._options.rename[_this._options.headers.indexOf(header)] || header;
       });
+
+      if (this._options.forceTextDelimiter) {
+        headers = headers.map(function (header) {
+          return '' + _this._options.textDelimiter + header + _this._options.textDelimiter;
+        });
+      }
+
       return headers.join(this._options.rowDelimiter);
     }
   }]);

--- a/lib/core/escape-delimiters.js
+++ b/lib/core/escape-delimiters.js
@@ -31,13 +31,11 @@ module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTe
         value.indexOf(endOfLine) >= 0);
 
   return function(value) {
-    if(!forceTextDelim) {
-      if (!value.replace) return value;
-      // Escape the textDelimiters contained in the field
-      value = value.replace(textDelimiterRegex, escapedDelimiter);
-    } else {
-      value = "" + value;
-    }
+    if(forceTextDelim) value = "" + value;
+
+    if (!value.replace) return value;
+    // Escape the textDelimiters contained in the field
+    value = value.replace(textDelimiterRegex, escapedDelimiter);
     
     // Escape the whole field if it contains a rowDelimiter or a linebreak or double quote
     if (forceTextDelim || enclosingCondition(value)) {

--- a/lib/core/escape-delimiters.js
+++ b/lib/core/escape-delimiters.js
@@ -9,7 +9,7 @@
    For example: "aaa","b""bb","ccc"
 */
 
-module.exports = function escapedDelimiters(textDelimiter, rowDelimiter) {
+module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTextDelim) {
   let endOfLine = '\n';
 
   if (typeof textDelimiter !== 'string') {
@@ -31,14 +31,17 @@ module.exports = function escapedDelimiters(textDelimiter, rowDelimiter) {
         value.indexOf(endOfLine) >= 0);
 
   return function(value) {
-    if (!value.replace) return value;
-    // Escape the textDelimiters contained in the field
-    var newValue = value.replace(textDelimiterRegex, escapedDelimiter);
-    // Escape the whole field if it contains a rowDelimiter or a linebreak or double quote
-    if (enclosingCondition(value)) {
-      newValue = textDelimiter + newValue + textDelimiter;
+    if(!forceTextDelim) {
+      if (!value.replace) return value;
+      // Escape the textDelimiters contained in the field
+      value = value.replace(textDelimiterRegex, escapedDelimiter);
     }
 
-    return newValue;
+    // Escape the whole field if it contains a rowDelimiter or a linebreak or double quote
+    if (enclosingCondition(value)) {
+      value = textDelimiter + value + textDelimiter;
+    }
+
+    return value;
   };
 };

--- a/lib/core/escape-delimiters.js
+++ b/lib/core/escape-delimiters.js
@@ -35,10 +35,12 @@ module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTe
       if (!value.replace) return value;
       // Escape the textDelimiters contained in the field
       value = value.replace(textDelimiterRegex, escapedDelimiter);
+    } else {
+      value = "" + value;
     }
-
+    
     // Escape the whole field if it contains a rowDelimiter or a linebreak or double quote
-    if (enclosingCondition(value)) {
+    if (forceTextDelim || enclosingCondition(value)) {
       value = textDelimiter + value + textDelimiter;
     }
 

--- a/lib/core/escape-delimiters.js
+++ b/lib/core/escape-delimiters.js
@@ -9,7 +9,7 @@
    For example: "aaa","b""bb","ccc"
 */
 
-module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTextDelim) {
+module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTextDelimiter) {  
   let endOfLine = '\n';
 
   if (typeof textDelimiter !== 'string') {
@@ -31,14 +31,14 @@ module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTe
         value.indexOf(endOfLine) >= 0);
 
   return function(value) {
-    if(forceTextDelim) value = "" + value;
+    if(forceTextDelimiter) value = "" + value;
 
     if (!value.replace) return value;
     // Escape the textDelimiters contained in the field
     value = value.replace(textDelimiterRegex, escapedDelimiter);
     
     // Escape the whole field if it contains a rowDelimiter or a linebreak or double quote
-    if (forceTextDelim || enclosingCondition(value)) {
+    if (forceTextDelimiter || enclosingCondition(value)) {
       value = textDelimiter + value + textDelimiter;
     }
 

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -16,7 +16,8 @@ class Parser {
     this._headers = this._options.headers || [];
     this._escape = require('../core/escape-delimiters')(
       this._options.textDelimiter,
-      this._options.rowDelimiter
+      this._options.rowDelimiter,
+      this._options.forceTextDelim
     );
   }
 
@@ -169,6 +170,7 @@ class Parser {
       includeHeaders: true, //     Boolean
       fillGaps: false, //          Boolean
       verticalOutput: true, //     Boolean
+      forceTextDelim: false, //    Boolean
       //Handlers
       handleString: undefined, //  Function
       handleNumber: undefined, //  Function

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -17,7 +17,7 @@ class Parser {
     this._escape = require('../core/escape-delimiters')(
       this._options.textDelimiter,
       this._options.rowDelimiter,
-      this._options.forceTextDelim
+      this._options.forceTextDelimiter
     );
   }
 
@@ -42,7 +42,7 @@ class Parser {
     if (this._options.rename && this._options.rename.length > 0)
       headers = headers.map((header) => this._options.rename[this._options.headers.indexOf(header)] || header);
       
-    if(this._options.forceTextDelim) {       
+    if(this._options.forceTextDelimiter) {       
       headers = headers.map((header) => {
         return `${this._options.textDelimiter}${header}${this._options.textDelimiter}`;
       });
@@ -178,7 +178,7 @@ class Parser {
       includeHeaders: true, //     Boolean
       fillGaps: false, //          Boolean
       verticalOutput: true, //     Boolean
-      forceTextDelim: false, //    Boolean
+      forceTextDelimiter: false, //Boolean
       //Handlers
       handleString: undefined, //  Function
       handleNumber: undefined, //  Function

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -38,8 +38,16 @@ class Parser {
 
   get headers() {
     let headers = this._headers;
+
     if (this._options.rename && this._options.rename.length > 0)
       headers = headers.map((header) => this._options.rename[this._options.headers.indexOf(header)] || header);
+      
+    if(this._options.forceTextDelim) {       
+      headers = headers.map((header) => {
+        return `${this._options.textDelimiter}${header}${this._options.textDelimiter}`;
+      });
+    }
+
     return headers.join(this._options.rowDelimiter);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonexport",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Makes easy to convert JSON to CSV",
   "main": "./lib",
   "scripts": {

--- a/tests/escape-delimiters.js
+++ b/tests/escape-delimiters.js
@@ -38,7 +38,7 @@ describe('escapeDelimiters', () => {
   });
 
   it('should escape if forceTextDelimiter flag is true', () => {
-    let escapeDelimiters = require('../lib/core/escape-delimiters')('"', '\n', true);
+    var escapeDelimiters = require('../lib/core/escape-delimiters')('"', '\n', false);
 
     expect(escapeDelimiters(mocks.forceEscape)).to.be.a.string;
     expect(escapeDelimiters(mocks.forceEscape)).to.be.equal('"42"');

--- a/tests/escape-delimiters.js
+++ b/tests/escape-delimiters.js
@@ -13,7 +13,8 @@ describe('escapeDelimiters', () => {
     simpleText: 'I am a "quoted" field',
     simpleRow: 'I am a \n multi line field',
     complexField: 'I am a \n multi line field containing "textDelimiters"',
-    alreadyEscaped: '"I contain "double quotes" everywhere !"'
+    alreadyEscaped: '"I contain "double quotes" everywhere !"',
+    forceEscape: 42
   };
 
   it('should escape textDelimiters', () => {
@@ -34,5 +35,12 @@ describe('escapeDelimiters', () => {
   it('should escape both textDelimiters and rowDelimiters', () => {
     expect(escapeDelimiters(mocks.complexField)).to.be.a.string;
     expect(escapeDelimiters(mocks.complexField)).to.be.equal('"I am a \n multi line field containing ""textDelimiters"""');
+  });
+
+  it('should escape if forceTextDelimiter flag is true', () => {
+    let escapeDelimiters = require('../lib/core/escape-delimiters')('"', '\n', true);
+
+    expect(escapeDelimiters(mocks.forceEscape)).to.be.a.string;
+    expect(escapeDelimiters(mocks.forceEscape)).to.be.equal('"42"');
   });
 });

--- a/tests/escape-delimiters.js
+++ b/tests/escape-delimiters.js
@@ -38,7 +38,7 @@ describe('escapeDelimiters', () => {
   });
 
   it('should escape if forceTextDelimiter flag is true', () => {
-    var escapeDelimiters = require('../lib/core/escape-delimiters')('"', '\n', false);
+    var escapeDelimiters = require('../lib/core/escape-delimiters')('"', '\n', true);
 
     expect(escapeDelimiters(mocks.forceEscape)).to.be.a.string;
     expect(escapeDelimiters(mocks.forceEscape)).to.be.equal('"42"');


### PR DESCRIPTION
## Status
READY

## Description
Some csv parsers (in our case a Spark csv parser) will throw errors if there are some items in a column that feature double quotes while others do not. This flag alleviates this issue by allowing the user to decide to wrap every data item and header in the text delimiter.

## Related PRs
none

## Todos
- [x] Tests
- [x] Documentation


## Steps to Test or Reproduce

```sh
git pull --prune
git checkout master
bundle; script/server
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Changes escape-delimiters to include forceTextDelim option flag
* adds additional logic in headers function to use forceTextDelim option flag
